### PR TITLE
Fix seller-context auth-session bug (+ checkout/e2e fixes); full e2e green

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -22,18 +22,57 @@ backendAxiosInstance.interceptors.request.use((config) => {
     return config;
 });
 
+// Users Endpoints
+import { _getMe, _updateUser, _getNonce, _verifySIWE, _refreshToken, _logout } from "./services/users";
+
+// Single-flight token refresh: concurrent 401s share ONE /api/auth/refresh call
+// (no refresh stampede / burst-logout), and the failed request is retried once with
+// the fresh access token. A transient 401 — e.g. the in-memory JWT gap right after a
+// navigation, or an expired access token (BE-16, 1h TTL) — is recovered via the
+// httpOnly refresh cookie instead of dropping the session. We only log out if the
+// refresh itself fails.
+let refreshPromise: Promise<string | null> | null = null;
+
+function refreshAccessToken(): Promise<string | null> {
+    if (!refreshPromise) {
+        refreshPromise = _refreshToken()
+            .then((res) => res.data?.token ?? null)
+            .catch(() => null)
+            .finally(() => {
+                refreshPromise = null;
+            });
+    }
+    return refreshPromise;
+}
+
+// Pre-auth endpoints and the refresh/logout calls themselves must NOT trigger a
+// refresh-and-retry (retrying the refresh would recurse).
+const NO_REFRESH_RETRY = /\/api\/auth\/(nonce|verify|refresh|logout)/;
+
 backendAxiosInstance.interceptors.response.use(
     (res) => res,
-    (err) => {
-        if (err?.response?.status === 401) {
+    async (err) => {
+        const original = err?.config;
+        const status = err?.response?.status;
+        if (
+            status === 401 &&
+            original &&
+            !original._retry &&
+            !NO_REFRESH_RETRY.test(original.url ?? "")
+        ) {
+            original._retry = true;
+            const token = await refreshAccessToken();
+            if (token) {
+                store.dispatch(login(token));
+                original.headers = original.headers ?? {};
+                original.headers.Authorization = `Bearer ${token}`;
+                return backendAxiosInstance(original);
+            }
             store.dispatch(logoutAction());
         }
         return Promise.reject(err);
     }
 );
-
-// Users Endpoints
-import { _getMe, _updateUser, _getNonce, _verifySIWE, _refreshToken, _logout } from "./services/users";
 
 // FE-4: the JWT is held in memory only and is not persisted. After a reload a
 // previously-authenticated session rehydrates with `isLoggedIn: true` but no token,
@@ -44,13 +83,13 @@ export async function bootstrapAuth(): Promise<void> {
     const state = store.getState();
     try {
         if (state.auth?.isLoggedIn && !state.auth?.jwt) {
-            const res = await _refreshToken();
-            const token = res.data?.token;
+            // Share the interceptor's single-flight refresh: the refresh token is
+            // single-use/rotating (BE-16), so two concurrent refreshes would
+            // invalidate each other.
+            const token = await refreshAccessToken();
             if (token) store.dispatch(login(token));
             else store.dispatch(logoutAction());
         }
-    } catch {
-        store.dispatch(logoutAction());
     } finally {
         store.dispatch(setBootstrapped());
     }

--- a/api/services/products.ts
+++ b/api/services/products.ts
@@ -21,12 +21,10 @@ export const _getProducts = async (
   id: string,
   cursor: string
 ): Promise<AxiosResponse<IProduct[]>> =>
-  backendAxiosInstance.get(`/api/products/store/${id}?cursor=${cursor}&limit=10`, {
-    headers: {
-      "Content-Type": "application/json",
-      "Access-Control-Expose-Headers": "next-cursor",
-    },
-  });
+  // FE-15: no client-set Access-Control-* headers. `next-cursor` is a RESPONSE
+  // header the backend already exposes via CORS; setting it as a request header
+  // only added a non-allowlisted header that fails the credentialed preflight.
+  backendAxiosInstance.get(`/api/products/store/${id}?cursor=${cursor}&limit=10`);
 
 export const _getOrders = async (filter: string): Promise<AxiosResponse<IOrder[]>> =>
   backendAxiosInstance.get(`/api/products/orders?filter=${filter}`);

--- a/e2e/fixtures/wallet.ts
+++ b/e2e/fixtures/wallet.ts
@@ -26,6 +26,7 @@ export const ESCROW_ABI = [
   "function createOrder(bytes32 orderId, bytes32 productId, address receiver, uint256 releaseTime) payable",
   "function releaseOrder(bytes32 orderId)",
   "function claimOrder(bytes32 orderId)",
+  "function markShipped(bytes32 orderId, bytes32 trackingHash)",
   "function refundOrder(bytes32 orderId)",
   "function raiseDisputeBuyer(bytes32 orderId) payable",
   "function raiseDisputeReceiver(bytes32 orderId) payable",
@@ -137,6 +138,19 @@ export function escrowAs(account: TestAccount) {
   return new ethers.Contract(ESCROW_ADDRESS, ESCROW_ABI, signerFor(account));
 }
 
+/**
+ * Receiver marks an order shipped. The contract is ship-gated (SC-1 + shipment
+ * escrow): claim/release and dispute are only allowed AFTER shipment, so the
+ * lifecycle/dispute specs must ship first. `trackingHash` is opaque on-chain.
+ */
+export async function markShipped(receiver: TestAccount, orderId: string) {
+  const tx = await escrowAs(receiver).markShipped(
+    orderIdToBytes32(orderId),
+    ethers.id(`e2e-tracking-${orderId}`),
+  );
+  await tx.wait();
+}
+
 export const provider = new ethers.JsonRpcProvider(RPC_URL);
 
 export type TestAccount = { address: string; key: string };
@@ -224,9 +238,21 @@ export async function installWallet(context: BrowserContext, account: TestAccoun
         networkVersion: String(parseInt(chainId, 16)),
         selectedAddress: addr,
         isConnected: () => true,
-        request: (args: { method: string; params?: unknown[] }) =>
+        request: (args: { method: string; params?: unknown[] }) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (window as any).__walletRequest(args.method, args.params ?? []),
+          const w = window as any;
+          // E2E partial-failure: reject the Nth escrow send (1-based) so the
+          // checkout's per-item loop can be exercised. One-shot — cleared after it
+          // fires, so the retry attempt's sends go through.
+          if (args.method === "eth_sendTransaction") {
+            w.__e2eSendCount = (w.__e2eSendCount || 0) + 1;
+            if (w.__e2eRejectSendIndex && w.__e2eSendCount === w.__e2eRejectSendIndex) {
+              w.__e2eRejectSendIndex = undefined;
+              return Promise.reject({ code: 4001, message: "User rejected the request." });
+            }
+          }
+          return w.__walletRequest(args.method, args.params ?? []);
+        },
         enable: () =>
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).__walletRequest("eth_requestAccounts", []),

--- a/e2e/tests/02-order-lifecycle.spec.ts
+++ b/e2e/tests/02-order-lifecycle.spec.ts
@@ -6,6 +6,7 @@ import {
   increaseTime,
   readOrder,
   escrowAs,
+  markShipped,
   orderIdToBytes32,
   provider,
   ACCOUNTS,
@@ -154,6 +155,9 @@ test("full ETH order lifecycle: list → buy → escrow → claim", async () => 
 
     const pre = await readOrder(orderId);
     if (!pre.completed) {
+      // Ship-gated claim (SC-1 + shipment escrow): the receiver must mark the order
+      // shipped before it can be claimed after the release window.
+      if (!pre.shipped) await markShipped(ACCOUNTS.seller, orderId);
       await increaseTime(RELEASE_WINDOW_SECONDS + 60);
 
       const treasury: string = await escrow.treasury();

--- a/e2e/tests/03-dispute-refund.spec.ts
+++ b/e2e/tests/03-dispute-refund.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import {
   createEscrowOrder,
   escrowAs,
+  markShipped,
   readOrder,
   readDispute,
   arbitrationCost,
@@ -63,6 +64,10 @@ test("buyer raising a dispute flips the order to disputed and records a dispute 
     receiver: ACCOUNTS.seller,
     amountWei: amount,
   });
+
+  // SC-1: disputes are only allowed after shipment (pre-shipment the buyer's remedy
+  // is buyerReclaim). The receiver ships, then the buyer can dispute.
+  await markShipped(ACCOUNTS.seller, orderId);
 
   // Buyer escrows their share of the arbitration fee to open the dispute.
   const cost = await arbitrationCost();

--- a/e2e/tests/05-partial-failure-checkout.spec.ts
+++ b/e2e/tests/05-partial-failure-checkout.spec.ts
@@ -142,10 +142,13 @@ test("one rejected item is left in the cart; retry only re-charges the unpaid it
   });
 
   await test.step("one item's tx is rejected → 'N of M paid' surfaces, paid item leaves the cart", async () => {
-    // Arm the wallet to reject the next escrow send (the per-item loop submits them
-    // sequentially; whichever item escrows first is "paid", the next is rejected).
+    // Arm the wallet to reject the SECOND escrow send: the per-item loop submits them
+    // sequentially, so item 1 escrows ("paid") and item 2 is rejected — the checkout
+    // stops at the first failure, leaving exactly one paid (→ "1 of 2 paid"). One-shot,
+    // so the later retry sends succeed.
     await buyerPage.evaluate(() => {
-      (window as unknown as { __e2eRejectNextSend?: boolean }).__e2eRejectNextSend = true;
+      (window as unknown as { __e2eRejectSendIndex?: number; __e2eSendCount?: number }).__e2eRejectSendIndex = 2;
+      (window as unknown as { __e2eSendCount?: number }).__e2eSendCount = 0;
     });
 
     await buyerPage.getByRole("button", { name: /pay with eth/i }).click();

--- a/next.config.js
+++ b/next.config.js
@@ -7,17 +7,26 @@ const cdnBase =
   process.env.NEXT_PUBLIC_CDN_BASE_URL ||
   "https://bucket-for-bazaar.fra1.cdn.digitaloceanspaces.com";
 
-let cdnHost;
+// Derive protocol + host + port from the CDN base so the pattern matches the
+// ACTUAL URL — including http://localhost:8000 in local-storage dev (previously
+// hardcoded https with no port, so next/image rejected dev images and the page
+// that rendered them crashed).
+let cdnPattern;
 try {
-  cdnHost = new URL(cdnBase).hostname;
+  const u = new URL(cdnBase);
+  cdnPattern = {
+    protocol: u.protocol.replace(":", ""),
+    hostname: u.hostname,
+    ...(u.port ? { port: u.port } : {}),
+  };
 } catch {
-  cdnHost = "bucket-for-bazaar.fra1.cdn.digitaloceanspaces.com";
+  cdnPattern = { protocol: "https", hostname: "bucket-for-bazaar.fra1.cdn.digitaloceanspaces.com" };
 }
 
 const nextConfig = {
   images: {
     remotePatterns: [
-      { protocol: "https", hostname: cdnHost },
+      cdnPattern,
       // DigitalOcean Spaces direct (non-CDN) origin, just in case.
       { protocol: "https", hostname: "*.digitaloceanspaces.com" },
       { protocol: "https", hostname: "avatars.githubusercontent.com" },


### PR DESCRIPTION
## The bug
After seller login, `getMe` 200s then a **burst of 401s** redirected to `/auth/login`. Root cause: the axios response interceptor logged out on **any** 401 with no refresh attempt, so a transient 401 (the FE-4 in-memory-JWT gap on navigation, or an expired 1h access token) dropped the session — and concurrent requests produced the burst.

## Fix (diagnosed with captured console + network)
- **Single-flight refresh + retry-once** on 401: concurrent 401s share ONE `/api/auth/refresh`, the original request is retried with the fresh token, and we log out **only if the refresh itself fails**. `bootstrapAuth` shares the same in-flight promise (the refresh token is single-use/rotating, BE-16). The refresh cookie scope was already correct (Path=/api/auth, SameSite=Lax, withCredentials).

## Downstream bugs surfaced once login persisted (real, app-affecting)
- `_getProducts` set a bogus `Access-Control-Expose-Headers` **request** header → failed the credentialed preflight → store page never loaded products. Removed.
- `next.config` images hardcoded `protocol: https` (no port) → `next/image` rejected dev images (`http://localhost:8000`) → page crashed. Now derives protocol+host+port from the CDN base.
- (paired backend PR: `Order.Fee` empty-string → numeric column 22P02 on order creation.)

## E2E (now real, not masked)
Ship-gated lifecycle/dispute (SC-1 + shipment escrow): `markShipped` before claim/dispute. Implemented the injected wallet's send-rejection (was never wired) so the partial-failure loop is truly exercised. **All 11 specs pass on a fresh stack** (login, lifecycle, dispute/refund, multi-item, partial-failure, pricing).

Stacked on `feat/vault-redesign` — kept separate from the styling PR #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)